### PR TITLE
Replace old sc2ai.net/.com links with aiarena.net and stylize name as two words

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Before proceeding, ensure the following prerequisites are installed:
 - [Poetry](https://python-poetry.org/) 
 - [Git](https://git-scm.com/)
 - [Starcraft 2](https://starcraft2.com/en-gb/) 
-- [Maps](https://sc2ai.net/wiki/maps/) Ensure maps are moved to the correct folder as suggested in this wiki.
+- [Maps](https://aiarena.net/wiki/maps/) Ensure maps are moved to the correct folder as suggested in this wiki.
 
 
 **Additional:**
@@ -81,11 +81,11 @@ If everything has worked thus far, open up `bot/main.py` and delve into the ex
 
 An `ares-sc2` bot is a [python-sc2](https://github.com/BurnySc2/python-sc2) bot by default, meaning any examples or documentation from that repository equally relevant here.
 
-## Uploading to [AiArena](https://www.sc2ai.com/)
+## Uploading to [AI Arena](https://www.aiarena.net/)
 
 ### Generating a ladder zip
 Included in the repository is a convenient script named `scripts/create_ladder_zip.py`. 
-However, it is important to note that the AIarena ladder infrastructure operates specifically 
+However, it is important to note that the AI Arena ladder infrastructure operates specifically 
 on Linux-based systems. Due to the dependency of ares-sc2 on cython, it is necessary to execute 
 this script on a Linux environment in order to generate Linux binaries.
 
@@ -94,20 +94,20 @@ pushing to `main` on your GitHub repository (if you previously created a templ
 from the [starter-bot](https://github.com/AresSC2/ares-sc2-starter-bot)). 
 Upon each push to the main branch, the `create_ladder_zip.py` script is automatically
 executed on a Debian-based system. As a result, a compressed artifact 
-named `ladder-zip.zip` is generated, facilitating the subsequent upload to AIarena. 
+named `ladder-zip.zip` is generated, facilitating the subsequent upload to AI Arena. 
 To access the generated file, navigate to the Actions tab, click on an Action and refer to the 
 Artifacts section. Please note this may take a few minutes after pusing to the `main` branch.
 
 Ladder zips can also be built on a debian based OS, with docker or via WSL.
 
-### Upload to aiarena
+### Upload to AI Arena
 The GitHub workflow includes an optional step to automatically upload the ladder-zip.zip artifact from 
-the previous step to the [AiArena ladder](https://www.sc2ai.com/). This feature is disabled by default. 
+the previous step to the [AI Arena ladder](https://www.aiarena.net/). This feature is disabled by default. 
 To enable it, follow these steps:
 
 1. Set `AutoUploadToAiarena: True` in `config.yml`.
-2. Visit the AiArena ladder and create an account if you don't have one.
-3. If necessary, set up a new bot via the AiArena website.
+2. Visit the AI Arena ladder and create an account if you don't have one.
+3. If necessary, set up a new bot via the AI Arena website.
 4. Navigate to your bot's profile and note your bot ID, which can be found in the URL.
 5. Go to `Profile -> View API Token` and save the token string.
 6. In your bot's GitHub repository, navigate to `Settings -> Secrets and variables -> Actions`.
@@ -117,7 +117,7 @@ UPLOAD_API_TOKEN: <aiarena_api_token> <br />
 UPLOAD_BOT_ID: <bot_id>
 
 After completing these steps, the next push to the main branch will build the ladder zip artifact 
-and automatically upload it to AiArena. You can customize this workflow as needed.
+and automatically upload it to AI Arena. You can customize this workflow as needed.
 
 ---
 # Additional


### PR DESCRIPTION
As requested [here](https://github.com/AresSC2/CustomManagerExample/pull/1#issuecomment-2454281515)

This PR replaces old sc2ai.net/.com links with aiarena.net.
I've also taken the liberty of stylizing the AI Arena name with a space in between.