### PR TITLE
refactor: add configurable AI Arena upload privacy settings

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,6 +8,9 @@ MyBotRace: Protoss
 # setting ture allows auto upload to aiareana (https://aiarena.net/) on push to `main` branch
 # see tutorial on readme before setting to True
 AutoUploadToAiarena: False
+BotZipPubliclyDownloadable: False
+BotDataPubliclyDownloadable: False
+BotDataEnabled: True
 ########################
 
 UseData: False

--- a/scripts/upload_to_ai_arena.py
+++ b/scripts/upload_to_ai_arena.py
@@ -9,6 +9,9 @@ API_TOKEN_ENV: str = "UPLOAD_API_TOKEN"
 BOT_ID_ENV: str = "UPLOAD_BOT_ID"
 CONFIG_FILE: str = "config.yml"
 AUTO_UPLOAD_TO_AIARENA: str = "AutoUploadToAiarena"
+BOT_ZIP_PUBLICLY_DOWNLOADABLE: str = "BotZipPubliclyDownloadable"
+BOT_DATA_PUBLICLY_DOWNLOADABLE: str = "BotDataPubliclyDownloadable"
+BOT_DATA_ENABLED: str = "BotDataEnabled"
 MY_BOT_NAME: str = "MyBotName"
 ZIPFILE_NAME: str = "bot.zip"
 
@@ -57,14 +60,26 @@ if __name__ == "__main__":
 
     else:
         logger.info("Uploading bot")
+        bot_zip_public = retrieve_value_from_config(BOT_ZIP_PUBLICLY_DOWNLOADABLE)
+        if bot_zip_public is None:
+            bot_zip_public = False
+
+        bot_data_public = retrieve_value_from_config(BOT_DATA_PUBLICLY_DOWNLOADABLE)
+        if bot_data_public is None:
+            bot_data_public = False
+
+        bot_data_enabled = retrieve_value_from_config(BOT_DATA_ENABLED)
+        if bot_data_enabled is None:
+            bot_data_enabled = True
+
         with open(ZIPFILE_NAME, "rb") as bot_zip:
             request_headers = {
                 "Authorization": f"Token {TOKEN}",
             }
             request_data = {
-                "bot_zip_publicly_downloadable": True,
-                "bot_data_publicly_downloadable": False,
-                "bot_data_enabled": False,
+                "bot_zip_publicly_downloadable": bot_zip_public,
+                "bot_data_publicly_downloadable": bot_data_public,
+                "bot_data_enabled": bot_data_enabled,
                 "wiki_article_content": get_bot_description(),
             }
             request_files = {


### PR DESCRIPTION
## Summary
This PR makes AI Arena upload privacy flags configurable via `config.yml` instead of hardcoded in `scripts/upload_to_ai_arena.py`.

## Changes
- Added config keys:
  - `BotZipPubliclyDownloadable` (default: `False`)
  - `BotDataPubliclyDownloadable` (default: `False`)
  - `BotDataEnabled` (default: `True`)
- Updated upload script to read these values from config.
- Added fallback defaults in code when keys are missing.
- Replaced hardcoded request payload values with config-driven values.

## Why
This allows bot authors to control AI Arena upload privacy behavior without editing script internals.
